### PR TITLE
Fix: bug when boolean false was extracted from var as nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.idea/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/json_logic/evaluator.rb
+++ b/lib/json_logic/evaluator.rb
@@ -96,7 +96,7 @@ module JsonLogic
       end
 
       if rules.is_a?(Hash)
-        rules.each { |_, rule| fetch_var_values(rule, var_name, values) }
+        rules.each_value { |rule| fetch_var_values(rule, var_name, values) }
         return values
       end
 
@@ -134,7 +134,7 @@ module JsonLogic
       rescue TypeError
         data = data[key.to_i]
       end
-      data || default_value
+      data.nil? ? default_value : data
     end
 
     # This method retrieves the variable name from a hash of rules based on the given operator.

--- a/spec/json_logic/evaluator_spec.rb
+++ b/spec/json_logic/evaluator_spec.rb
@@ -191,6 +191,20 @@ RSpec.describe JsonLogic::Evaluator do
 
         it { is_expected.to be_nil }
       end
+
+      context 'when value is true' do
+        let(:data) { { 'a' => true } }
+        let(:var_name) { 'a' }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context 'when value is false' do
+        let(:data) { { 'a' => false } }
+        let(:var_name) { 'a' }
+
+        it { is_expected.to be(false) }
+      end
     end
 
     context 'when data is array' do

--- a/spec/json_logic/evaluator_spec.rb
+++ b/spec/json_logic/evaluator_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe JsonLogic::Evaluator do
         let(:data) { { 'a' => true } }
         let(:var_name) { 'a' }
 
-        it { is_expected.to be_truthy }
+        it { is_expected.to be(true) }
       end
 
       context 'when value is false' do

--- a/spec/json_logic/validator_spec.rb
+++ b/spec/json_logic/validator_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe JsonLogic::Validator do
       it { is_expected.to be_truthy }
     end
 
+    context 'when valid operator with false' do
+      let(:rules) { { 'and' => [{ '==' => [{ 'var' => 'green_card' }, false] }] } }
+
+      it { is_expected.to be_truthy }
+    end
+
     context 'when valid operator with hash' do
       let(:rules) { { '==' => [{ 'var' => 'temp' }, { 'x' => 'y' }] } }
 


### PR DESCRIPTION
Fixed bug when method #`get_var_value` extracts from boolean variable `nil` instead of `false`