### PR TITLE
fix: Add support of complex not (!) operator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_logic_ruby (0.2.3)
+    json_logic_ruby (0.2.4)
       activesupport (~> 7.0)
 
 GEM

--- a/lib/json_logic/concerns/trackable.rb
+++ b/lib/json_logic/concerns/trackable.rb
@@ -2,6 +2,8 @@
 
 module JsonLogic
   module Trackable
+    COMPLEX_OPERATORS = %w[and or if ! !! ?:].freeze
+
     attr_reader :tracker
 
     def init_tracker(operator)
@@ -12,15 +14,34 @@ module JsonLogic
       end
     end
 
-    def commit_rule_result!(var_name, operator, data, rules, result)
+    def commit_rule_result!(operator, data, rules, result)
       if COMPLEX_OPERATORS.include?(operator)
         # change operand to parent & save result
         @tracker.result = result
         @tracker        = @tracker.parent unless @tracker.parent.nil?
         return result
       end
+      var_name = get_var_name(operator, rules)
       @tracker.add_data_point(var_name, operator, rules, data, result)
       result
+    end
+
+    private
+
+    # This method retrieves the variable name from a hash of rules based on the given operator.
+    #   { "<=" : [ 25, { "var": "age" }, 75] }
+    #   { "<=" : [ { "var" : "age" }, 20 ] }
+    #
+    # @param operator [String] The operator for which to retrieve the variable name.
+    # @param rules [Hash] A hash containing rule data.
+    # @return [String, nil] The variable name if found, otherwise nil.
+
+    def get_var_name(operator, rules)
+      args = rules[operator]
+      index = COMPLEX_OPERATORS.exclude?(operator) && args.length == 3 ? 1 : 0
+      args.dig(index, 'var')
+    rescue TypeError
+      nil
     end
   end
 end

--- a/lib/json_logic/operations.rb
+++ b/lib/json_logic/operations.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module JsonLogic
-  COMPLEX_OPERATORS = %w[and or if].freeze
-
   OPERATIONS = {
     '==' => ->(a, b) { a == b },
     '!=' => ->(a, b) { a != b },

--- a/lib/json_logic/version.rb
+++ b/lib/json_logic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JsonLogic
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/spec/json_logic/evaluator_spec.rb
+++ b/spec/json_logic/evaluator_spec.rb
@@ -152,6 +152,24 @@ RSpec.describe JsonLogic::Evaluator do
 
       it { is_expected.to eq(result) }
     end
+
+    context 'when not(!)' do
+      let(:rules) do
+        { '!' => { '<=' => [70, { 'var' => 'age' }, 75] } }
+      end
+
+      context 'when age is not in range' do
+        let(:data) { { 'age' => 50 } }
+
+        it { is_expected.to be(true) }
+      end
+
+      context 'when age is in range' do
+        let(:data) { { 'age' => 70 } }
+
+        it { is_expected.to be(false) }
+      end
+    end
   end
 
   describe '#get_var_name' do
@@ -308,7 +326,7 @@ RSpec.describe JsonLogic::Evaluator do
   end
 
   describe '#fetch_var_values' do
-    subject { described_class.new.send(:fetch_var_values, rules, var_name) }
+    subject { described_class.new.fetch_var_values(rules, var_name) }
 
     context 'when variable present' do
       let(:rules) do


### PR DESCRIPTION
Added ability to run complex ! with nested logic.
![image](https://github.com/useful-libs/json_logic_ruby/assets/1535772/3b50c7cd-02e4-4d0f-adf5-d4087444bdc7)
 